### PR TITLE
Uppercase pieces

### DIFF
--- a/client/board.js
+++ b/client/board.js
@@ -4,14 +4,14 @@ import Square from './square.js';
 export default class Board {
     constructor() {
         this.squares = {
-            a1: 'wr', b1: 'wn', c1: 'wb', d1: 'wq', e1: 'wk', f1: 'wb', g1: 'wn', h1: 'wr',
-            a2: 'wp', b2: 'wp', c2: 'wp', d2: 'wp', e2: 'wp', f2: 'wp', g2: 'wp', h2: 'wp',
+            a1: 'WR', b1: 'WN', c1: 'WB', d1: 'WQ', e1: 'WK', f1: 'WB', g1: 'WN', h1: 'WR',
+            a2: 'WP', b2: 'WP', c2: 'WP', d2: 'WP', e2: 'WP', f2: 'WP', g2: 'WP', h2: 'WP',
             a3: '', b3: '', c3: '', d3: '', e3: '', f3: '', g3: '', h3: '',
             a4: '', b4: '', c4: '', d4: '', e4: '', f4: '', g4: '', h4: '',
             a5: '', b5: '', c5: '', d5: '', e5: '', f5: '', g5: '', h5: '',
             a6: '', b6: '', c6: '', d6: '', e6: '', f6: '', g6: '', h6: '',
-            a7: 'bp', b7: 'bp', c7: 'bp', d7: 'bp', e7: 'bp', f7: 'bp', g7: 'bp', h7: 'bp',
-            a8: 'br', b8: 'bn', c8: 'bb', d8: 'bq', e8: 'bk', f8: 'bb', g8: 'bn', h8: 'br',
+            a7: 'BP', b7: 'BP', c7: 'BP', d7: 'BP', e7: 'BP', f7: 'BP', g7: 'BP', h7: 'BP',
+            a8: 'BR', b8: 'BN', c8: 'BB', d8: 'BQ', e8: 'BK', f8: 'BB', g8: 'BN', h8: 'BR',
         };
         this.risks = {};
         this.turn = 'White';

--- a/client/piece.js
+++ b/client/piece.js
@@ -1,17 +1,17 @@
 export default class Piece {
     static list = {
-        bb: { symbol: '&#9821;', color: 'Black', type: 'Bishop' },
-        bk: { symbol: '&#9818;', color: 'Black', type: 'King' },
-        bn: { symbol: '&#9822;', color: 'Black', type: 'Knight' },
-        bp: { symbol: '&#9823;', color: 'Black', type: 'Pawn' },
-        bq: { symbol: '&#9819;', color: 'Black', type: 'Queen' },
-        br: { symbol: '&#9820;', color: 'Black', type: 'Rook' },
-        wb: { symbol: '&#9815;', color: 'White', type: 'Bishop' },
-        wk: { symbol: '&#9812;', color: 'White', type: 'King' },
-        wn: { symbol: '&#9816;', color: 'White', type: 'Knight' },
-        wp: { symbol: '&#9817;', color: 'White', type: 'Pawn' },
-        wq: { symbol: '&#9813;', color: 'White', type: 'Queen' },
-        wr: { symbol: '&#9814;', color: 'White', type: 'Rook' },
+        BB: { symbol: '&#9821;', color: 'Black', type: 'Bishop' },
+        BK: { symbol: '&#9818;', color: 'Black', type: 'King' },
+        BN: { symbol: '&#9822;', color: 'Black', type: 'Knight' },
+        BP: { symbol: '&#9823;', color: 'Black', type: 'Pawn' },
+        BQ: { symbol: '&#9819;', color: 'Black', type: 'Queen' },
+        BR: { symbol: '&#9820;', color: 'Black', type: 'Rook' },
+        WB: { symbol: '&#9815;', color: 'White', type: 'Bishop' },
+        WK: { symbol: '&#9812;', color: 'White', type: 'King' },
+        WN: { symbol: '&#9816;', color: 'White', type: 'Knight' },
+        WP: { symbol: '&#9817;', color: 'White', type: 'Pawn' },
+        WQ: { symbol: '&#9813;', color: 'White', type: 'Queen' },
+        WR: { symbol: '&#9814;', color: 'White', type: 'Rook' },
     };
 
     static draw(abbr) {

--- a/scripts/time-piece.js
+++ b/scripts/time-piece.js
@@ -21,7 +21,7 @@ const functions = [
     checkPieceExists,
 ];
 
-const input = ['bb', 'bk', 'bn', 'bp', 'bq', 'br', 'wb', 'wk', 'wn', 'wp', 'wq', 'wr', ''];
+const input = ['BB', 'BK', 'BN', 'BP', 'BQ', 'BR', 'WB', 'WK', 'WN', 'WP', 'WQ', 'WR', ''];
 
 const max = 1e7;
 for (const f of functions) {


### PR DESCRIPTION
Algebraic notation uses uppercase letters for the piece. Also, this helps to distinguish pieces from squares out of context.