### PR TITLE
Fix validate().

### DIFF
--- a/client/board.js
+++ b/client/board.js
@@ -93,8 +93,8 @@ export default class Board {
                 // Copy the board, then try a move without updating whose
                 // turn it is, to see whether the king will be in check.
                 const board = structuredClone(this);
-                board[move] = piece;
-                board[origin] = '';
+                board.squares[move] = piece;
+                board.squares[origin] = '';
                 board.risks = Board.findRisks(board);
                 board.king = Board.findKing(board, board.turn);
                 board.check = board.king in board.risks;


### PR DESCRIPTION
The purpose of validate() is to see whether a move puts or leaves the king in check. Previously, it was not moving the piece.

I introduced this bug in: 9dab09f39d46241ec4857537bb73f085e7eacd1b