### PR TITLE
Automatically promote the pawn to a queen.

### DIFF
--- a/client/board.js
+++ b/client/board.js
@@ -605,6 +605,10 @@ export default class Board {
             const skip = toFile + rank;
             this.enPassant = skip;
         }
+        else if (toRank === 1 || toRank === 8) {
+            // Automatically promote the pawn to a queen.
+            this.squares[from] = this.squares[from][0] + 'Q';
+        }
         return true;
     }
 


### PR DESCRIPTION
The rules allow the player to choose between a queen, rook, bishop, or knight. This is better than leaving the pawn, which is not allowed.