### PR TITLE
Fix square size.

### DIFF
--- a/client/main.css
+++ b/client/main.css
@@ -52,6 +52,7 @@ button#new-game {
 }
 
 table {
+    table-layout: fixed;
     border-spacing: 0;
     height: var(--size);
     width: var(--size);
@@ -66,7 +67,7 @@ td {
     position: relative;
     color: black;
     cursor: default;
-    font-size: calc(var(--square) * 0.8);
+    font-size: calc(var(--square) * 0.85);
     border: 5px solid transparent;
     height: var(--square);
     width: var(--square);
@@ -122,16 +123,12 @@ td.selected:hover {
 
 @media only screen and (width <= 480px) {
     :root {
-        --size: min(94.5vh, 100vw);
+        --size: min(94.5vh, 96vw);
+        --square: calc((var(--size) / 8) - 8px);
     }
 
     body {
         margin: 0;
-    }
-
-    #board td {
-        font-size: 2.5rem;
-        height: calc(100vw / 8);
     }
 }
 


### PR DESCRIPTION
Previously, table cells would shrink slightly depending on whether the rank or file was empty. On large screens (tablets, etc.) empty files would shrink, and on narrow screens (phones) empty ranks would shrink. This change makes all squares a consisten size regardless of their contents.