### PR TITLE
Strongly avoid a draw, with sufficient material.

### DIFF
--- a/client/board.js
+++ b/client/board.js
@@ -975,8 +975,8 @@ export default class Board {
             rating += 100;
         }
         else if (board.draw !== '') {
-            const drawValue = canWin === true ? -1 : 100;
-            this.logRating(from, to, drawValue, 'Draw');
+            const drawValue = canWin === true ? -100 : 100;
+            this.logRating(from, to, drawValue, `Draw due to ${board.draw}`);
             rating += drawValue;
         }
         else if (board.check === true) {


### PR DESCRIPTION
Previously, the rating to avoid a draw wasn't enough to demote a move from the highest rating. This resulted in many draws due to fivefold repetition.